### PR TITLE
convert duration to string before suing split to extract parts

### DIFF
--- a/autohb.rb
+++ b/autohb.rb
@@ -161,7 +161,7 @@ class AutoHB
     end
 
     def parse_duration(duration)
-        parts = duration.split ':'
+        parts = duration.to_s.split ':'
 	Duration.new :hours => parts[0].to_i, :minutes => parts[1].to_i, :seconds => parts[2].to_i
     end
 


### PR DESCRIPTION
Signed-off-by: Sebastian Rutofski <sebastian.rutofski@gmail.com>

Fixes #3 be explicitly converting the extracted duration to string before splitting.