### PR TITLE
Improve diagnostics when invalid --subtitle specified

### DIFF
--- a/autohb.rb
+++ b/autohb.rb
@@ -459,12 +459,22 @@ class AutoHB
         if lang == "scan"
             return lang
         end
-        subtitles = @titles[@titles_to_rip.first].subtitles
+        title = @titles_to_rip.first ? @titles_to_rip.first.to_i : 1
+        subtitles = @titles[title].subtitles
         subtitles.each do |subtitle|
+            if subtitle.nil?
+                next
+            end
             if subtitle.lang == lang
                 return subtitle.number
             end
         end
+        langs = subtitles.reject(&:nil?).collect(&:lang)
+        raise <<~EX.chomp
+              no subtitle language "#{lang}" found (for track #{title}).
+              valid --subtitle= options (for that track, anyway):
+              #{langs.inspect}
+              EX
     end
 
     def get_subtitles


### PR DESCRIPTION
Hi

Thanks so much for this program. It has made my slog through transferring a DVD set i acquired to my media box a breeze.

I ran into an issue though, when i specified `--subtitle=eng`, as suggested (probably not literally, though i had no clue) in the `--help` message. Turns out, my DVD only features (inter alia) "English" (unabbreviated), but autohb only told me:

    autohb.rb:462:in `get_subtitle_track': no implicit conversion of String into Integer (TypeError)
            from autohb.rb:654:in `main'
            from autohb.rb:933:in `<top (required)>'

So i modified `get_subtitle_track` with some code i copy-pasted from `get_subtitles` to result in the branch i'm requesting being pulled into yours, which, to my illegal `--subtitle` specification, ponies up

    autohb.rb:473:in `get_subtitle_track': no subtitle language "eng" found (for track 1). (RuntimeError)
    valid --subtitle= options (for that track, anyway):
    ["English", "Francais", "español", "Portugues", "ไทย", "English,"]

(I have no idea what that last one, "English," with the comma, is. I'm itchin' to try it, though)

Of course, that's at the top of the call stacktrace, so it may not be all that helpful, and my ruby has never been for public consumption, so it may not be exactly a paragon of style, so you may just wanna take the gist of it and do something more suitable for your purposes, if you see any merit at all in this.

Anyways, again, thanks for this very time-saving program.

And, for the record, i was running the version at commit 890781e87f8e of Fri Dec 2 22:05:18 2022 +0000 on ubuntu 22.04 (jammy), which (for anybody else with a box running that distro who hasn't done so yet) i got to build courtesy of an `apt-get install ruby-bundler`, an `apt-get install ruby-dev`, and an `apt-get install g++` (didn't even have a C++ compiler installed on that box) along with replacing the line in the Gemfile that says

    gem 'taglib-ruby'

with

    gem 'taglib-ruby', '~> 1.1.3'

which seems to be the version available just after you made that last commit, because the older GNU C++ versions available with "jammy" don't support some of the newer C++ syntax in the latest taglib-ruby version 2.0.0. (I further followed the suggestion in the comment by Iuri Guilherme at Jun 16, 2022 at 15:25 on [this stackoverflow answer](https://stackoverflow.com/a/12663612) to `bundle install` the gems locally in my AutoHandbrake directory and then ran it a la `bundle exec autohb.rb`)
